### PR TITLE
Log message: Use log.info for "Create Connection" instead of log.error

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -379,7 +379,7 @@ class event2amqp():
 
         # connection management
         if not self.connected():
-            logger.error("[Canopsis] Create connection")
+            logger.info("[Canopsis] Create connection")
             self.create_connection()
             self.connect()
 


### PR DESCRIPTION
Every time a connection is created, there is an "error" message in the shinken logs. I think it's a little bit confuse to new users, because it's not an error, it's just an information message for the incoming connection.
