### PR TITLE
Bug fixes and missing import

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -32,6 +32,7 @@ import sys
 import os
 import pickle
 import time
+import socket
 
 from collections import deque
 
@@ -353,6 +354,9 @@ class event2amqp():
             return False
 
     def connected(self):
+        if not self.connection:
+            return False
+
         try:
             # Try to establish a connection
             self.connection._connection = self.connection.transport.establish_connection()


### PR DESCRIPTION
Missing import of socket module for the exception `socket.error`.

Method `connected()` returns `False` when `self.connection` doesn't exist.
