### PR TITLE
Fixed a tuple index out of range

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -187,7 +187,7 @@ class Canopsis_broker(BaseModule):
 
         except Exception, err:
             logger.error("[Canopsis] Error: there was an error while trying to create message for service")
-            logger.debug('[Canopsis] {0}: {1}'.format(err))
+            logger.debug('[Canopsis] Error: {0}'.format(err))
             return
 
         if not message:


### PR DESCRIPTION
2014-09-08 13:05:28,657 [1410174328] Warning : [broker-master] Back trace of this kill: Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/shinken/daemons/brokerdaemon.py", line 245, in manage_brok
    mod.manage_brok(b)
  File "/var/lib/shinken/modules/canopsis/module.py", line 112, in manage_brok
    self.manage_service_check_result_brok(b)
  File "/var/lib/shinken/modules/canopsis/module.py", line 187, in manage_service_check_result_brok
    logger.debug('[Canopsis] {0}: {1}'.format(err))
IndexError: tuple index out of range
