### PR TITLE
Fixes discarding host events when from_q queue is None

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -99,8 +99,10 @@ class Canopsis_broker(BaseModule):
             logger.info('[Canopsis] Ask the broker for instance id (#{0}) data'.format(c_id))
 
             msg = Message(id=0, type='NeedData', data={'full_instance_id': c_id}, source=self.get_name())
-            if self.from_q:
+            try:
                 self.from_q.put(msg)
+            except AttributeError, e:
+                logger.warning('[Canopsis] Asking reinit: from_q queue is not initialized ({0})'.format(e))
 
             self.last_need_data_send = time.time()
 


### PR DESCRIPTION
This is a grave bug because every time ask_reinit() is called from create_message() and self.from_q is None, the complete message is discarded due a captured Exception.

```
2014-09-26 14:18:39,417 [1411733919] Error :   [broker-master] [Canopsis] Error: there was an error while trying to create message for host
2014-09-26 14:18:39,417 [1411733919] Error :   [broker-master] [Canopsis] Error: 'NoneType' object has no attribute 'put'
```
